### PR TITLE
feat: new oidc client with custom redirect uri

### DIFF
--- a/services/idp/pkg/config/config.go
+++ b/services/idp/pkg/config/config.go
@@ -61,6 +61,7 @@ type Client struct {
 	ID              string   `yaml:"id"`
 	Name            string   `yaml:"name"`
 	Trusted         bool     `yaml:"trusted"`
+	// Insecure        bool     `yaml:"insecure"`
 	Secret          string   `yaml:"secret"`
 	RedirectURIs    []string `yaml:"redirect_uris"`
 	Origins         []string `yaml:"origins"`

--- a/services/idp/pkg/config/defaults/defaultconfig.go
+++ b/services/idp/pkg/config/defaults/defaultconfig.go
@@ -94,6 +94,20 @@ func DefaultConfig() *config.Config {
 				},
 			},
 			{
+				ID:              "sdk",
+				Secret:          "UBntmLjC2yYCeHwsyj73Uwo9TAaecAetRwMw0xYcvNL9yRdLSUi0hUAHfvCHFeFh",
+				Name:            "Integration app",
+				// ApplicationType: "native", // default is "web"
+				// Insecure: true, // not supported yet (default is false)
+				RedirectURIs: []string{
+					// 1. If config doesn't support "Insecure" option,
+					//    we need to use secure "https" instead of "http".
+					// 2. One of the redirect URIs should exactly match the actual redirect url
+					"https://localhost",
+					"https://host.docker.internal",
+				},
+			},
+			{
 				ID:              "e4rAsNUSIUs0lF4nbv9FmCeUkTlV9GdgTLDH1b5uie7syb90SzEVrbN7HIpmWJeD",
 				Secret:          "dInFYGV33xKzhbRmpqQltYNdfLdJIfJ9L5ISoKhNoT9qZftpdWSP71VrpGR9pmoD",
 				Name:            "ownCloud Android app",


### PR DESCRIPTION
Adding custom client with custom redirect URIs other than localhost.

Key points:
- `ApplicationType: native` doesn't allow redirect URIs other than `localhost`
- `ApplicationType: web` supports custom redirect URIs
- If config doesn't support `Insecure` option, we need to use secure `https` instead of `http`.
- One of the redirect URIs should exactly match the actual redirect url

The same can be done using `.yaml` config file without code changes.
**NOTE**:
- looks like other clients are also required as it is
- order matters (custom client must be after `web` and `desktop app` clients)

Example:
```yml
# idp.yaml
clients:
  - id: web
    name: ownCloud Web app
    trusted: true
    secret: ""
    redirect_uris:
      - https://localhost:9200/
      - https://localhost:9200/oidc-callback.html
      - https://localhost:9200/oidc-silent-redirect.html
    origins:
      - https://localhost:9200
    application_type: ""
  - id: xdXOt13JKxym1B1QcEncf2XDkLAexMBFwiT9j6EfhhHFJhs2KM9jbjTmf8JBXE69
    name: ownCloud desktop app
    trusted: false
    secret: UBntmLjC2yYCeHwsyj73Uwo9TAaecAetRwMw0xYcvNL9yRdLSUi0hUAHfvCHFeFh
    redirect_uris:
      - http://127.0.0.1
      - http://localhost
    origins: []
    application_type: native
  - id: e4rAsNUSIUs0lF4nbv9FmCeUkTlV9GdgTLDH1b5uie7syb90SzEVrbN7HIpmWJeD
    name: ownCloud Android app
    trusted: false
    secret: dInFYGV33xKzhbRmpqQltYNdfLdJIfJ9L5ISoKhNoT9qZftpdWSP71VrpGR9pmoD
    redirect_uris:
      - oc://android.owncloud.com
    origins: []
    application_type: native
  - id: mxd5OQDk6es5LzOzRvidJNfXLUZS2oN3oUFeXPP8LpPrhx3UroJFduGEYIBOxkY1
    name: ownCloud iOS app
    trusted: false
    secret: KFeFWWEZO9TkisIQzR3fo7hfiMXlOpaqP8CFuTbSHzV1TUuGECglPxpiVKJfOXIx
    redirect_uris:
      - oc://ios.owncloud.com
    origins: []
    application_type: native
  #
  # new client
  #
  - id: sdk
    name: Integration app
    trusted: false
    secret: UBntmLjC2yYCeHwsyj73Uwo9TAaecAetRwMw0xYcvNL9yRdLSUi0hUAHfvCHFeFh
    redirect_uris:
      - https://localhost
      - https://host.docker.internal
    origins: []
    application_type: ""
```